### PR TITLE
Add weekly and yearly charts to horse dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -263,6 +263,8 @@ def horse_detail(request: Request, horse_id: int):
 
     monthly_rows, weekly_rows, yearly_rows = accum_periods(rides)
     month_series = [{"label": m["period"], "km": m["km"]} for m in monthly_rows]
+    week_series = [{"label": w["period"], "km": w["km"]} for w in weekly_rows]
+    year_series = [{"label": y["period"], "km": y["km"]} for y in yearly_rows]
 
     top_long = sorted(rides, key=lambda r: r.distance_km, reverse=True)[:3]
     top_fast = sorted(rides, key=lambda r: r.max_speed_kmh, reverse=True)[:3]
@@ -271,7 +273,8 @@ def horse_detail(request: Request, horse_id: int):
     return templates.TemplateResponse("horse_detail.html", {
         "request": request, "horse": horse, "rides": rides,
         "monthly": monthly_rows, "weekly": weekly_rows, "yearly": yearly_rows,
-        "month_series": month_series, "stats": stats,
+        "month_series": month_series, "week_series": week_series, "year_series": year_series,
+        "stats": stats,
         "top_long": top_long, "top_fast": top_fast, "top_climb": top_climb,
         "q_from": None, "q_to": None,
     })

--- a/app/templates/horse_detail.html
+++ b/app/templates/horse_detail.html
@@ -22,10 +22,14 @@
       <div><div class="muted">Ø rychlost</div><div><b>{{ '%.2f' % stats.avg }}</b></div></div>
       <div><div class="muted">Max rychlost</div><div><b>{{ '%.2f' % stats.max }}</b></div></div>
     </div>
+    <div id="gauge_avg" style="height:150px;"></div>
+    <div id="gauge_max" style="height:150px;"></div>
   </div>
   <div class="card">
-    <h3>Měsíce / Roky</h3>
+    <h3>Měsíce / Týdny / Roky</h3>
     <div id="chart_months"></div>
+    <div id="chart_weeks"></div>
+    <div id="chart_years"></div>
   </div>
 </section>
 
@@ -56,5 +60,35 @@ Plotly.newPlot('chart_months', [{
   y: months.map(m=>m.km),
   type: 'bar'
 }], {title:'Najeté km podle měsíců', margin:{t:30}, displayModeBar:false});
+
+const weeks = {{ week_series | safe }};
+Plotly.newPlot('chart_weeks', [{
+  x: weeks.map(m=>m.label),
+  y: weeks.map(m=>m.km),
+  type: 'bar'
+}], {title:'Najeté km podle týdnů', margin:{t:30}, displayModeBar:false});
+
+const years = {{ year_series | safe }};
+Plotly.newPlot('chart_years', [{
+  x: years.map(m=>m.label),
+  y: years.map(m=>m.km),
+  type: 'bar'
+}], {title:'Najeté km podle let', margin:{t:30}, displayModeBar:false});
+
+Plotly.newPlot('gauge_avg', [{
+  type: 'indicator',
+  mode: 'gauge+number',
+  value: {{ '%.2f' % stats.avg }},
+  title: {text: 'Ø rychlost'},
+  gauge: {axis: {range: [0, 50]}}
+}], {margin:{t:30}, displayModeBar:false});
+
+Plotly.newPlot('gauge_max', [{
+  type: 'indicator',
+  mode: 'gauge+number',
+  value: {{ '%.2f' % stats.max }},
+  title: {text: 'Max rychlost'},
+  gauge: {axis: {range: [0, 50]}}
+}], {margin:{t:30}, displayModeBar:false});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- derive weekly and yearly distance series in the horse detail view
- show monthly, weekly, and yearly distance charts with Plotly
- include gauges for average and max speed stats

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aeec04dd188331b4861b4426e1e5fa